### PR TITLE
fix: make the endpoint public

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
     "slonik": "^23.0.2",
     "typescript": "^4.0.5"
   },
+  "dependencies": {
+    "graasp-plugin-public": "github:graasp/graasp-plugin-public"
+  },
   "packageManager": "yarn@3.2.0-rc.3"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export { default } from './plugin';
+export { default as publicPlugin } from './plugin';
 export { TaskManager } from './task-manager';
 export * from './types';

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,18 +1,28 @@
 // global
 import { FastifyPluginAsync } from 'fastify';
+import graaspPublicPlugin from 'graasp-plugin-public';
 
 // local
 import { SearchService } from './db-service';
 import { TaskManager } from './task-manager';
 import { search } from './schemas';
-import { GraaspSearchPluginOptions, Ranges } from './types';
+import { Ranges } from './types';
+import { Member } from 'graasp';
 
-const plugin: FastifyPluginAsync<GraaspSearchPluginOptions> = async (fastify, options) => {
+const publicPlugin: FastifyPluginAsync = async (fastify) => {
   const {
-    taskRunner: runner
+    taskRunner: runner,
+    public: {
+      graaspActor,
+      publishedTagId,
+    },
   } = fastify;
-  const searchService = new SearchService(options.publishedTagId);
+  const searchService = new SearchService(publishedTagId);
   const taskManager = new TaskManager(searchService);
+
+  if (!graaspPublicPlugin) {
+    throw new Error('Public plugin is not correctly defined');
+  }
 
   const getTaskByRange = (member, keyword, range) => {
     switch (range) {
@@ -32,12 +42,12 @@ const plugin: FastifyPluginAsync<GraaspSearchPluginOptions> = async (fastify, op
   fastify.get<{ Params: { keyword: string, range: string }; }>(
     '/search/:range/:keyword',
     { schema: search },
-    async ({ member, params: { keyword, range }, log }) => {
-      const task = getTaskByRange(member, keyword, range);
+    async ({ params: { keyword, range }, log }) => {
+      const task = getTaskByRange(graaspActor as Member, keyword, range);
       return runner.runSingle(task, log);
     },
   );
 
 };
 
-export default plugin;
+export default publicPlugin;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -7,7 +7,6 @@ import { SearchService } from './db-service';
 import { TaskManager } from './task-manager';
 import { search } from './schemas';
 import { Ranges } from './types';
-import { Member } from 'graasp';
 
 const publicPlugin: FastifyPluginAsync = async (fastify) => {
   const {
@@ -43,7 +42,7 @@ const publicPlugin: FastifyPluginAsync = async (fastify) => {
     '/search/:range/:keyword',
     { schema: search },
     async ({ params: { keyword, range }, log }) => {
-      const task = getTaskByRange(graaspActor as Member, keyword, range);
+      const task = getTaskByRange(graaspActor, keyword, range);
       return runner.runSingle(task, log);
     },
   );

--- a/src/task-manager.ts
+++ b/src/task-manager.ts
@@ -1,4 +1,4 @@
-import { ItemService, Member } from 'graasp';
+import { Actor, ItemService } from 'graasp';
 import { SearchService } from './db-service';
 import { SearchTaskManager } from './interfaces/search-task-manager';
 import { SearchByAllTask } from './tasks/search-by-all-task';
@@ -21,19 +21,19 @@ export class TaskManager implements SearchTaskManager {
   getSearchByAllTaskName(): string { return SearchByAllTask.name; }
   getSearchByAuthorTaskName(): string { return SearchByAuthorTask.name; }
 
-  createSearchByTitleTask(member: Member, keyword: string): SearchByTitleTask {
+  createSearchByTitleTask(member: Actor, keyword: string): SearchByTitleTask {
     return new SearchByTitleTask(member, this.searchService, {keyword: keyword});
   }
 
-  createSearchByTagTask(member: Member, keyword: string): SearchByTagTask {
+  createSearchByTagTask(member: Actor, keyword: string): SearchByTagTask {
     return new SearchByTagTask(member, this.searchService, {keyword: keyword});
   }
 
-  createSearchByAllTask(member: Member, keyword: string): SearchByAllTask {
+  createSearchByAllTask(member: Actor, keyword: string): SearchByAllTask {
     return new SearchByAllTask(member, this.searchService, {keyword: keyword});
   }
 
-  createSearchByAuthorTask(member: Member, keyword: string): SearchByAuthorTask {
+  createSearchByAuthorTask(member: Actor, keyword: string): SearchByAuthorTask {
     return new SearchByAuthorTask(member, this.searchService, {keyword: keyword});
   }
 }

--- a/src/tasks/base-search-task.ts
+++ b/src/tasks/base-search-task.ts
@@ -1,7 +1,6 @@
 // global
 import { FastifyLoggerInstance } from 'fastify';
 import { Actor, Task, TaskStatus, IndividualResultType, PreHookHandlerType, PostHookHandlerType, DatabaseTransactionHandler } from 'graasp';
-import { Member } from 'graasp';
 // local
 import { SearchService } from '../db-service';
 
@@ -10,7 +9,7 @@ export abstract class BaseSearchTask<R> implements Task<Actor, R> {
   protected _result: R;
   protected _message: string;
 
-  readonly actor: Member;
+  readonly actor: Actor;
 
   status: TaskStatus;
   data: Partial<IndividualResultType<R>>;
@@ -22,7 +21,7 @@ export abstract class BaseSearchTask<R> implements Task<Actor, R> {
   getInput?: () => unknown;
   getResult?: () => unknown;
 
-  constructor(actor: Member, searchService: SearchService) {
+  constructor(actor: Actor, searchService: SearchService) {
     this.actor = actor;
     this.searchService = searchService;
     this.status = 'NEW';

--- a/src/tasks/search-by-all-task.ts
+++ b/src/tasks/search-by-all-task.ts
@@ -1,5 +1,5 @@
 // global
-import { DatabaseTransactionHandler, Item, Member } from 'graasp';
+import { Actor, DatabaseTransactionHandler, Item } from 'graasp';
 // local
 import { SearchService } from '../db-service';
 import { BaseSearchTask } from './base-search-task';
@@ -14,7 +14,7 @@ export class SearchByAllTask extends BaseSearchTask<Item[]> {
     return SearchByAllTask.name;
   }
 
-  constructor(member: Member, searchService: SearchService, input: InputType) {
+  constructor(member: Actor, searchService: SearchService, input: InputType) {
     super(member, searchService);
     this.input = input;
   }

--- a/src/tasks/search-by-author-task.ts
+++ b/src/tasks/search-by-author-task.ts
@@ -1,5 +1,5 @@
 // global
-import { DatabaseTransactionHandler, Item, Member } from 'graasp';
+import { Actor, DatabaseTransactionHandler, Item } from 'graasp';
 // local
 import { SearchService } from '../db-service';
 import { BaseSearchTask } from './base-search-task';
@@ -14,7 +14,7 @@ export class SearchByAuthorTask extends BaseSearchTask<Item[]> {
     return SearchByAuthorTask.name;
   }
 
-  constructor(member: Member, searchService: SearchService, input: InputType) {
+  constructor(member: Actor, searchService: SearchService, input: InputType) {
     super(member, searchService);
     this.input = input;
   }

--- a/src/tasks/search-by-tag-task.ts
+++ b/src/tasks/search-by-tag-task.ts
@@ -1,5 +1,5 @@
 // global
-import { DatabaseTransactionHandler, Item, Member } from 'graasp';
+import { DatabaseTransactionHandler, Item, Actor } from 'graasp';
 // local
 import { SearchService } from '../db-service';
 import { BaseSearchTask } from './base-search-task';
@@ -14,7 +14,7 @@ export class SearchByTagTask extends BaseSearchTask<Item[]> {
     return SearchByTagTask.name;
   }
 
-  constructor(member: Member, searchService: SearchService, input: InputType) {
+  constructor(member: Actor, searchService: SearchService, input: InputType) {
     super(member, searchService);
     this.input = input;
   }

--- a/src/tasks/search-by-title-task.ts
+++ b/src/tasks/search-by-title-task.ts
@@ -1,5 +1,5 @@
 // global
-import { DatabaseTransactionHandler, Item, Member } from 'graasp';
+import { Actor, DatabaseTransactionHandler, Item } from 'graasp';
 // local
 import { SearchService } from '../db-service';
 import { BaseSearchTask } from './base-search-task';
@@ -14,7 +14,7 @@ export class SearchByTitleTask extends BaseSearchTask<Item[]> {
     return SearchByTitleTask.name;
   }
 
-  constructor(member: Member, searchService: SearchService, input: InputType) {
+  constructor(member: Actor, searchService: SearchService, input: InputType) {
     super(member, searchService);
     this.input = input;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,8 @@
+import { Actor } from 'graasp';
+
 export interface GraaspSearchPluginOptions {
   publishedTagId: string;
+  graaspActor: Actor;
 }
 
 export enum Ranges {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,3 @@
-import { Actor } from 'graasp';
-
-export interface GraaspSearchPluginOptions {
-  publishedTagId: string;
-  graaspActor: Actor;
-}
-
 export enum Ranges {
   Title = 'title',
   Tag = 'tag',

--- a/yarn.lock
+++ b/yarn.lock
@@ -467,6 +467,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"call-bind@npm:^1.0.0":
+  version: 1.0.2
+  resolution: "call-bind@npm:1.0.2"
+  dependencies:
+    function-bind: ^1.1.1
+    get-intrinsic: ^1.0.2
+  checksum: f8e31de9d19988a4b80f3e704788c4a2d6b6f3d17cfec4f57dc29ced450c53a49270dc66bf0fbd693329ee948dd33e6c90a329519aef17474a4d961e8d6426b0
+  languageName: node
+  linkType: hard
+
 "callsites@npm:^3.0.0":
   version: 3.1.0
   resolution: "callsites@npm:3.1.0"
@@ -891,10 +901,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fastify-cors@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "fastify-cors@npm:6.0.2"
+  dependencies:
+    fastify-plugin: ^3.0.0
+    vary: ^1.1.2
+  checksum: f600eb30d2259bf0277c3df72c73f09f6891f3984c62e1c9a7489f0d6b2ffb1749dbe9a79a05ad74b08a660c1a707c9fb7636c20b87d07eae0e6efd9c951fd03
+  languageName: node
+  linkType: hard
+
 "fastify-error@npm:^0.3.0":
   version: 0.3.1
   resolution: "fastify-error@npm:0.3.1"
   checksum: fd6a0f6f87b5e4ab59a4d3d66124bd13830a1cf85cf1987259dfb1175fc6a4bcae68b076ad78f6bb06654f72af133b44813090e9ce5502d2ef56ddcb2b0fa867
+  languageName: node
+  linkType: hard
+
+"fastify-plugin@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "fastify-plugin@npm:3.0.0"
+  checksum: 00324690789ee02f977ab58ba70d937e2e420a6813a6aa7ae3ba47e34022dc8ac40e15a36ab14a67d94474de984398b1c8b30279fb51d92966f5d3d3ebd1b6fa
   languageName: node
   linkType: hard
 
@@ -1005,10 +1032,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"function-bind@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "function-bind@npm:1.1.1"
+  checksum: b32fbaebb3f8ec4969f033073b43f5c8befbb58f1a79e12f1d7490358150359ebd92f49e72ff0144f65f2c48ea2a605bff2d07965f548f6474fd8efd95bf361a
+  languageName: node
+  linkType: hard
+
 "functional-red-black-tree@npm:^1.0.1":
   version: 1.0.1
   resolution: "functional-red-black-tree@npm:1.0.1"
   checksum: ca6c170f37640e2d94297da8bb4bf27a1d12bea3e00e6a3e007fd7aa32e37e000f5772acf941b4e4f3cf1c95c3752033d0c509af157ad8f526e7f00723b9eb9f
+  languageName: node
+  linkType: hard
+
+"get-intrinsic@npm:^1.0.2":
+  version: 1.1.1
+  resolution: "get-intrinsic@npm:1.1.1"
+  dependencies:
+    function-bind: ^1.1.1
+    has: ^1.0.3
+    has-symbols: ^1.0.1
+  checksum: a9fe2ca8fa3f07f9b0d30fb202bcd01f3d9b9b6b732452e79c48e79f7d6d8d003af3f9e38514250e3553fdc83c61650851cb6870832ac89deaaceb08e3721a17
   languageName: node
   linkType: hard
 
@@ -1077,6 +1122,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"graasp-item-tags@github:graasp/graasp-item-tags":
+  version: 0.1.0
+  resolution: "graasp-item-tags@https://github.com/graasp/graasp-item-tags.git#commit=59a4a525b47acd73948a9b5fba70ece000073300"
+  dependencies:
+    http-status-codes: 2.2.0
+  checksum: ebd32e6ef983f599a84f08246acb712aa656e89902920cd8b152ebedeff47ba91fa31e20dcf0e3c075b8f83497551d8975e1160dcce42962fa9b558803344469
+  languageName: node
+  linkType: hard
+
+"graasp-plugin-public@github:graasp/graasp-plugin-public":
+  version: 0.1.0
+  resolution: "graasp-plugin-public@https://github.com/graasp/graasp-plugin-public.git#commit=668dbccef04d5465655eb8ae44765d935b42c1fa"
+  dependencies:
+    fastify-cors: ^6.0.2
+    graasp-item-tags: "github:graasp/graasp-item-tags"
+    http-status-codes: ^2.2.0
+    qs: ^6.10.2
+  checksum: 276eed4964e0e4cc5f0fefc03938eac0e4972c88fa84769917bee6d5c6e47fdc4dc1d0a72becbcc747121ea2792249f60d36ee4699570c8369a5619f31c15c9a
+  languageName: node
+  linkType: hard
+
 "graasp-plugin-search@workspace:.":
   version: 0.0.0-use.local
   resolution: "graasp-plugin-search@workspace:."
@@ -1088,6 +1154,7 @@ __metadata:
     "@typescript-eslint/parser": ^4.7.0
     eslint: ^7.13.0
     fastify: ^3.8.0
+    graasp-plugin-public: "github:graasp/graasp-plugin-public"
     slonik: ^23.0.2
     typescript: ^4.0.5
   languageName: unknown
@@ -1104,6 +1171,29 @@ __metadata:
   version: 4.0.0
   resolution: "has-flag@npm:4.0.0"
   checksum: 261a1357037ead75e338156b1f9452c016a37dcd3283a972a30d9e4a87441ba372c8b81f818cd0fbcd9c0354b4ae7e18b9e1afa1971164aef6d18c2b6095a8ad
+  languageName: node
+  linkType: hard
+
+"has-symbols@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "has-symbols@npm:1.0.2"
+  checksum: 2309c426071731be792b5be43b3da6fb4ed7cbe8a9a6bcfca1862587709f01b33d575ce8f5c264c1eaad09fca2f9a8208c0a2be156232629daa2dd0c0740976b
+  languageName: node
+  linkType: hard
+
+"has@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "has@npm:1.0.3"
+  dependencies:
+    function-bind: ^1.1.1
+  checksum: b9ad53d53be4af90ce5d1c38331e712522417d017d5ef1ebd0507e07c2fbad8686fffb8e12ddecd4c39ca9b9b47431afbb975b8abf7f3c3b82c98e9aad052792
+  languageName: node
+  linkType: hard
+
+"http-status-codes@npm:2.2.0, http-status-codes@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "http-status-codes@npm:2.2.0"
+  checksum: 31e1d730856210445da0907d9b484629e69e4fe92ac032478a7aa4d89e5b215e2b4e75d7ebce40d0537b6850bd281b2f65c7cc36cc2677e5de056d6cea1045ce
   languageName: node
   linkType: hard
 
@@ -1387,6 +1477,13 @@ __metadata:
   version: 1.4.0
   resolution: "natural-compare@npm:1.4.0"
   checksum: 23ad088b08f898fc9b53011d7bb78ec48e79de7627e01ab5518e806033861bef68d5b0cd0e2205c2f36690ac9571ff6bcb05eb777ced2eeda8d4ac5b44592c3d
+  languageName: node
+  linkType: hard
+
+"object-inspect@npm:^1.9.0":
+  version: 1.12.0
+  resolution: "object-inspect@npm:1.12.0"
+  checksum: 2b36d4001a9c921c6b342e2965734519c9c58c355822243c3207fbf0aac271f8d44d30d2d570d450b2cc6f0f00b72bcdba515c37827d2560e5f22b1899a31cf4
   languageName: node
   linkType: hard
 
@@ -1699,6 +1796,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"qs@npm:^6.10.2":
+  version: 6.10.2
+  resolution: "qs@npm:6.10.2"
+  dependencies:
+    side-channel: ^1.0.4
+  checksum: 46fcc8f75a062524b91f9bf6b3843f346135b27d91c2a2dc3eb7ef9e34435703fd52e16d927f8864fd572d4b0ebc5a40a00649535108b8e8ea845a861b414369
+  languageName: node
+  linkType: hard
+
 "queue-microtask@npm:^1.1.2, queue-microtask@npm:^1.2.2":
   version: 1.2.3
   resolution: "queue-microtask@npm:1.2.3"
@@ -1878,6 +1984,17 @@ __metadata:
   version: 3.0.0
   resolution: "shebang-regex@npm:3.0.0"
   checksum: 1a2bcae50de99034fcd92ad4212d8e01eedf52c7ec7830eedcf886622804fe36884278f2be8be0ea5fde3fd1c23911643a4e0f726c8685b61871c8908af01222
+  languageName: node
+  linkType: hard
+
+"side-channel@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "side-channel@npm:1.0.4"
+  dependencies:
+    call-bind: ^1.0.0
+    get-intrinsic: ^1.0.2
+    object-inspect: ^1.9.0
+  checksum: 351e41b947079c10bd0858364f32bb3a7379514c399edb64ab3dce683933483fc63fb5e4efe0a15a2e8a7e3c436b6a91736ddb8d8c6591b0460a24bb4a1ee245
   languageName: node
   linkType: hard
 
@@ -2180,6 +2297,13 @@ __metadata:
   version: 2.3.0
   resolution: "v8-compile-cache@npm:2.3.0"
   checksum: adb0a271eaa2297f2f4c536acbfee872d0dd26ec2d76f66921aa7fc437319132773483344207bdbeee169225f4739016d8d2dbf0553913a52bb34da6d0334f8e
+  languageName: node
+  linkType: hard
+
+"vary@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "vary@npm:1.1.2"
+  checksum: ae0123222c6df65b437669d63dfa8c36cee20a504101b2fcd97b8bf76f91259c17f9f2b4d70a1e3c6bbcee7f51b28392833adb6b2770b23b01abec84e369660b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
close #4 

Use GRAASP_ACTOR to make endpoints public

- I use the same way as categories (import the public plugin repo). Initially I want to use the options method, but encountered some errors, so I do the same way as plugin-categories. Now it's working well locally.